### PR TITLE
Fixes #19: Updated setup.py; library now installs correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requires = [
 ]
 
 requires_dev = requires + [
-    "black>=20.",
+    "black>=22",
     "bump2version>=1.0.0",
     "check-manifest",
     "flake8>=3.7.8",


### PR DESCRIPTION
Updated requirement for black in setup.py, so the library can now be installed in developer mode without raising an error.